### PR TITLE
Treat MimeType in Content-Type as case-insensitive

### DIFF
--- a/restfly/utils.py
+++ b/restfly/utils.py
@@ -66,7 +66,7 @@ def format_json_response(response: Response,
     '''
     content_type = response.headers.get('content-type', 'application/json')
     if ((conv_json or conv_box)
-        and 'application/json' in content_type
+        and 'application/json' in content_type.lower()
         and len(response.text) > 0
     ):  # noqa: E124
         if conv_box:


### PR DESCRIPTION
Why
---
Tenable.io introduced a fun change which is technically RFC compliant, but very annoying.

They changed the Content-Type from `application/json` to `Application/json` in the HTTP responses from one of the API endpoints. As a result, this library will not treat the response and JSON and you end up with AttributeErrors in client code.

Like I said, it is technically compliant as RFC 7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content § 3.1.1.1. Media Type states:
> The type, subtype, and parameter name tokens are case-insensitive.
https://httpwg.org/specs/rfc7231.html#media.type

How
---
* Lowercase the response Content-Type header value before checking if it contains application/json