### PR TITLE
Publish wheel to PyPI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,8 @@ jobs:
                       pytest              \
                       pytest-cov          \
                       pytest-vcr          \
-                      pytest-datafiles
+                      pytest-datafiles    \
+                      wheel
           pip install -r requirements.txt
           pip install .
       - name: Lint with flake8
@@ -45,7 +46,7 @@ jobs:
           pytest --vcr-record=none --cov-report term-missing --cov=restfly tests
       - name: Build Package
         run: |
-          python setup.py sdist
+          python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.egg-info
 __pycache__
 .python-version
-dist
+/build
+/dist
 .vscode
 .DS_Store
 _build


### PR DESCRIPTION
Wheels are faster to install then source distributions. For packages like restfly the change is smaller because no binary compiling is needed on installation, but still the size to download is smaller:

```sh
$ du -h dist/*
28K	dist/restfly-1.4.5-py3-none-any.whl
176K	dist/restfly-1.4.5.tar.gz
```

See also: [Source Distributions vs Wheels](https://packaging.python.org/en/latest/tutorials/installing-packages/?highlight=wheel#source-distributions-vs-wheels).

---

In this implementation, I'm installing the `wheel` package in the GitHub workflow; an alternative would be to put it in `setup_requires` of `setup.py`.